### PR TITLE
Added Health-Damage System

### DIFF
--- a/Assets/Code/Bullet.cs
+++ b/Assets/Code/Bullet.cs
@@ -5,6 +5,11 @@ public class Bullet : MonoBehaviour
     private void OnCollisionEnter2D(Collision2D col)
     {
         Destroy(gameObject);
+        
+        if (col.gameObject.GetComponent<Health>() != null)
+        {
+            col.gameObject.GetComponent<Health>().TakeDamage(1);
+        }
     }
 
     private void Start()

--- a/Assets/Code/EnemyMovement.cs
+++ b/Assets/Code/EnemyMovement.cs
@@ -36,6 +36,7 @@ public class EnemyMovement : MonoBehaviour
         if (collision.gameObject.tag is "Player")
         {
             //Debug.Log("Ouchies");
+            collision.gameObject.GetComponent<Health>().TakeDamage(1);
         }
     }
 }

--- a/Assets/Code/Health.cs
+++ b/Assets/Code/Health.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Health : MonoBehaviour
+{
+    [SerializeField] protected int totalHealth;
+    protected int currentHealth;
+
+    // Start is called before the first frame update
+    private void Start()
+    {
+        currentHealth = totalHealth;
+        Debug.Log("Health is: " + totalHealth);
+    }
+
+    public virtual void TakeDamage(int damage)
+    {
+        currentHealth -= damage;
+        Debug.Log("Health is: " + currentHealth);
+
+        if (currentHealth <= 0)
+        {
+            //die - overriden for Player to restart level
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/Code/Health.cs.meta
+++ b/Assets/Code/Health.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9d9c1f60d868b64e843ad2e9bc89b62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Code/PlayerHealth.cs
+++ b/Assets/Code/PlayerHealth.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class PlayerHealth : Health
+{
+    public override void TakeDamage(int damage)
+    {
+        currentHealth -= damage;
+        Debug.Log("Health is: " + currentHealth);
+
+        if (currentHealth <= 0)
+        {
+            //reset game
+            SceneManager.LoadScene(SceneManager.GetActiveScene().name);
+        }
+    }
+}

--- a/Assets/Code/PlayerHealth.cs.meta
+++ b/Assets/Code/PlayerHealth.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ad023d7a3661d945865549cd70a769c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description

## Health
- Added generic `Health.cs` to use for all entities with health
- Added `PlayerHealth.cs` which inherits from `Health.cs` - this is needed so that the level can be reset when the player dies

## Damage
- Changed `Bullet.cs` to do 1 damage to anything with a health component (this needs to be changed in the future if we include damage modifiers)
- Changed `EnemyMovement.cs` to do 1 damage to the player on collision (this needs to be changed in the future when we include more enemies)